### PR TITLE
Revert SURFMS4.yaml

### DIFF
--- a/topology/Dutch National e-Infrastructure/SURF-ICT/SURFMS4.yaml
+++ b/topology/Dutch National e-Infrastructure/SURF-ICT/SURFMS4.yaml
@@ -26,4 +26,4 @@ Resources:
       XRootD cache server:
         Description: Cache at SURF-MS4 for LVK
     AllowedVOs:
-      - LIGO
+      - ANY


### PR DESCRIPTION
Our cache setup is currently broken and we can not test it with only this VO having access, so we revert temporarily to fix the set up and then restrict VOs again.